### PR TITLE
Replace FLREUnicode.pas & FastMM4 does support FPC

### DIFF
--- a/src/FLRELib.dpr
+++ b/src/FLRELib.dpr
@@ -3,18 +3,26 @@ library FLRELib;
  {$mode delphi}
 {$endif}
 
-{$ifndef fpc}
-{ FastMM4 in 'FastMM4.pas',
-  FastMove in 'FastMove.pas',
-  FastcodeCPUID in 'FastcodeCPUID.pas',
-  FastMM4Messages in 'FastMM4Messages.pas',}
-{$endif}
-
 uses
   SysUtils,
   Classes,
-  FLRE in 'FLRE.pas',
-  FLREUnicode in 'FLREUnicode.pas';
+  
+  {$ifdef fpc}
+   {$ifndef WINDOWS}
+    { // FastMM4 Library
+    FastMM4 in 'FastMM4.pas',
+    FastMM4Messages in 'FastMM4Messages.pas',}
+   {$endif}
+  {$endif}
+  
+  {$ifndef fpc}
+  { // Fastcode Library
+    FastMove in 'FastMove.pas',
+    FastcodeCPUID in 'FastcodeCPUID.pas',}
+  {$endif}
+  
+  PUCU in 'PUCU.pas',
+  FLRE in 'FLRE.pas';
 
 exports FLREGetVersion name 'FLREGetVersion',
         FLREGetVersionString name 'FLREGetVersionString',


### PR DESCRIPTION
As mentioned in https://github.com/BeRo1985/flre/issues/38, FLREUnicode isn't available anymore. (Fix for #38)
FastMM4 does also support FPC (seems only Windows is not supported -> https://github.com/pleriche/FastMM4/issues/20)