### PR TITLE
Hashmaps

### DIFF
--- a/src/FLRE.pas
+++ b/src/FLRE.pas
@@ -8501,7 +8501,6 @@ end;
 destructor TFLREDFAStateHashMap.Destroy;
 begin
  Clear;
- SetLength(Entities,0);
  inherited Destroy;
 end;
 
@@ -9197,24 +9196,14 @@ begin
 end;
 
 destructor TFLREStringIntegerPairHashMap.Destroy;
-var Counter:TFLREInt32;
 begin
  Clear;
- for Counter:=0 to length(Entities)-1 do begin
-  Entities[Counter].Key:='';
- end;
- SetLength(Entities,0);
- SetLength(EntityToCellIndex,0);
- SetLength(CellToEntityIndex,0);
  inherited Destroy;
 end;
 
 procedure TFLREStringIntegerPairHashMap.Clear;
 var Counter:TFLREInt32;
 begin
- for Counter:=0 to length(Entities)-1 do begin
-  Entities[Counter].Key:='';
- end;
  RealSize:=0;
  LogSize:=0;
  Size:=0;
@@ -9397,9 +9386,6 @@ end;
 destructor TFLRECharClassHashMap.Destroy;
 begin
  Clear;
- SetLength(Entities,0);
- SetLength(EntityToCellIndex,0);
- SetLength(CellToEntityIndex,0);
  inherited Destroy;
 end;
 
@@ -21790,24 +21776,13 @@ begin
 end;
 
 destructor TFLRECacheHashMap.Destroy;
-var Counter:TFLREInt32;
 begin
  Clear;
- for Counter:=0 to length(Entities)-1 do begin
-  Entities[Counter].Key:='';
- end;
- SetLength(Entities,0);
- SetLength(EntityToCellIndex,0);
- SetLength(CellToEntityIndex,0);
  inherited Destroy;
 end;
 
 procedure TFLRECacheHashMap.Clear;
-var Counter:TFLREInt32;
 begin
- for Counter:=0 to length(Entities)-1 do begin
-  Entities[Counter].Key:='';
- end;
  RealSize:=0;
  LogSize:=0;
  Size:=0;

--- a/src/FLRE.pas
+++ b/src/FLRE.pas
@@ -1269,7 +1269,6 @@ type EFLRE=class(Exception);
      TFLRECache=class
       private
        ParallelLock:TFLREParallelLock;
-       List:TList;
        HashMap:TFLRECacheHashMap;
       public
        constructor Create;
@@ -21835,17 +21834,14 @@ constructor TFLRECache.Create;
 begin
  inherited Create;
  ParallelLock:=0;
- List:=TList.Create;
  HashMap:=TFLRECacheHashMap.Create;
 end;
 
 destructor TFLRECache.Destroy;
 var Index:TFLREInt32;
 begin
- for Index:=0 to List.Count-1 do begin
-  TFLRE(List[Index]).Free;
- end;
- List.Free;
+ for Index:=0 to HashMap.Size - 1 do
+   HashMap.Entities[Index].Value.Free;
  HashMap.Free;
  inherited Destroy;
 end;
@@ -21855,10 +21851,8 @@ var Index:TFLREInt32;
 begin
  ParallelLockEnter(@ParallelLock);
  try
-  for Index:=0 to List.Count-1 do begin
-   TFLRE(List[Index]).Free;
-  end;
-  List.Clear;
+ for Index:=0 to HashMap.Size - 1 do
+   HashMap.Entities[Index].Value.Free;
   HashMap.Clear;
  finally
   ParallelLockLeave(@ParallelLock);
@@ -21874,7 +21868,6 @@ begin
   result:=HashMap.GetValue(HashKey);
   if not assigned(result) then begin
    result:=TFLRE.Create(ARegularExpression,AFlags);
-   List.Add(result);
    HashMap.Add(HashKey,result);
   end;
  finally
@@ -21895,7 +21888,6 @@ begin
   result:=HashMap.GetValue(HashKey);
   if not assigned(result) then begin
    result:=TFLRE.Create(ARegularExpressions,AFlags);
-   List.Add(result);
    HashMap.Add(HashKey,result);
   end;
  finally


### PR DESCRIPTION
I have closely examined the hashmap code, since I need a hashmap and FLRE's hashmap is faster than most. It is very impressive.

But there is a lot of duplicate code and freeing of things that are already freed by reference counting. This pull request removes them.

There are two things not addressed here. 
EntityToCellIndex is only used to track deleted entities, so it probably could be removed, by changing the detection to  empty keys or values.  it would reduce the memory use of the maps by like 25%.
Secondly, the same hashmap implementation occurs four times in FLRE. Surely that could be merged to a single generic hashmap?
