### PR TITLE
Make Delphi Happy, about those conditionals

### DIFF
--- a/src/FLRE.pas
+++ b/src/FLRE.pas
@@ -3699,9 +3699,9 @@ type TXMMValue=record
      end{$ifndef fpc}{$if CompilerVersion>=28.0}align 16{$ifend}{$endif};
 
 function PtrPosCharSetOf2Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -3807,10 +3807,10 @@ begin
 end;
 
 function PtrPosCharSetOf3Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -3942,11 +3942,11 @@ begin
 end;
 
 function PtrPosCharSetOf4Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -4095,12 +4095,12 @@ begin
 end;
 
 function PtrPosCharSetOf5Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
       XMM4Constant:TXMMValue=(Lo:TFLREQWord($0404040404040404);Hi:TFLREQWord($0404040404040404));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -4236,13 +4236,13 @@ begin
 end;
 
 function PtrPosCharSetOf6Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
       XMM4Constant:TXMMValue=(Lo:TFLREQWord($0404040404040404);Hi:TFLREQWord($0404040404040404));
       XMM5Constant:TXMMValue=(Lo:TFLREQWord($0505050505050505);Hi:TFLREQWord($0505050505050505));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -4389,14 +4389,14 @@ begin
 end;
 
 function PtrPosCharSetOf7Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
       XMM4Constant:TXMMValue=(Lo:TFLREQWord($0404040404040404);Hi:TFLREQWord($0404040404040404));
       XMM5Constant:TXMMValue=(Lo:TFLREQWord($0505050505050505);Hi:TFLREQWord($0505050505050505));
       XMM6Constant:TXMMValue=(Lo:TFLREQWord($0606060606060606);Hi:TFLREQWord($0606060606060606));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -4554,7 +4554,7 @@ begin
 end;
 
 function PtrPosCharSetOf8Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
@@ -4562,7 +4562,7 @@ const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($01
       XMM5Constant:TXMMValue=(Lo:TFLREQWord($0505050505050505);Hi:TFLREQWord($0505050505050505));
       XMM6Constant:TXMMValue=(Lo:TFLREQWord($0606060606060606);Hi:TFLREQWord($0606060606060606));
       XMM7Constant:TXMMValue=(Lo:TFLREQWord($0707070707070707);Hi:TFLREQWord($0707070707070707));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -4731,9 +4731,9 @@ begin
 end;
 
 function PtrPosCharPairSearch(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -4858,11 +4858,11 @@ begin
 end;
 
 function PtrPosCharSetOf2Of2Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -5029,13 +5029,13 @@ begin
 end;
 
 function PtrPosCharSetOf2Of3Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
       XMM4Constant:TXMMValue=(Lo:TFLREQWord($0404040404040404);Hi:TFLREQWord($0404040404040404));
       XMM5Constant:TXMMValue=(Lo:TFLREQWord($0505050505050505);Hi:TFLREQWord($0505050505050505));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -5190,7 +5190,7 @@ begin
 end;
 
 function PtrPosCharSetOf2Of4Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
@@ -5198,7 +5198,7 @@ const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($01
       XMM5Constant:TXMMValue=(Lo:TFLREQWord($0505050505050505);Hi:TFLREQWord($0505050505050505));
       XMM6Constant:TXMMValue=(Lo:TFLREQWord($0606060606060606);Hi:TFLREQWord($0606060606060606));
       XMM7Constant:TXMMValue=(Lo:TFLREQWord($0707070707070707);Hi:TFLREQWord($0707070707070707));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -5373,11 +5373,11 @@ begin
 end;
 
 function PtrPosCharRangeSearch(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM126Constant:TXMMValue=(Lo:TFLREQWord($7e7e7e7e7e7e7e7e);Hi:TFLREQWord($7e7e7e7e7e7e7e7e));
       XMM127Constant:TXMMValue=(Lo:TFLREQWord($7f7f7f7f7f7f7f7f);Hi:TFLREQWord($7f7f7f7f7f7f7f7f));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper
@@ -5490,13 +5490,13 @@ begin
 end;
 
 function PtrPosCharRangeOf2Search(const p:pointer;const v:TFLREQWord;const pEnd:pointer):TFLREPtrInt; assembler; register;
-{$if defined(fpc) and (fpc_version>=3)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$push}{$codealign localmin=16}{$codealign varmin=16}{$ifend}
 const XMM1Constant:TXMMValue=(Lo:TFLREQWord($0101010101010101);Hi:TFLREQWord($0101010101010101));
       XMM2Constant:TXMMValue=(Lo:TFLREQWord($0202020202020202);Hi:TFLREQWord($0202020202020202));
       XMM3Constant:TXMMValue=(Lo:TFLREQWord($0303030303030303);Hi:TFLREQWord($0303030303030303));
       XMM126Constant:TXMMValue=(Lo:TFLREQWord($7e7e7e7e7e7e7e7e);Hi:TFLREQWord($7e7e7e7e7e7e7e7e));
       XMM127Constant:TXMMValue=(Lo:TFLREQWord($7f7f7f7f7f7f7f7f);Hi:TFLREQWord($7f7f7f7f7f7f7f7f));
-{$if defined(fpc) and (fpc_version>=3)}{$pop}{$ifend}
+{$if defined(fpc) and (fpc_version>=3.0)}{$pop}{$ifend}
 asm
 {$ifdef Windows}
  // Win64 ABI to System-V ABI wrapper


### PR DESCRIPTION
  - Can't understand why in earth delphi even cares of second condition because of {$if defined(fpc) and should be enough, if thee is plau >=3 then Delphi complains with : [dcc32 Warning] FLRE.pas(5493): W1023 Comparing signed and unsigned types - widened both operands, hope this works OK in the FPC also